### PR TITLE
Subnet route table association

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2198,6 +2198,7 @@ describe subnet('my-subnet') do
 end
 ```
 
+
 ### be_associated_to
 
 ### be_available, be_pending

--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -2198,6 +2198,7 @@ describe subnet('my-subnet') do
 end
 ```
 
+### be_associated_to
 
 ### be_available, be_pending
 

--- a/lib/awspec/command/generate.rb
+++ b/lib/awspec/command/generate.rb
@@ -5,7 +5,7 @@ module Awspec
   class Generate < Thor
     class_option :profile
     class_option :region
-    class_option :secrets_path, default: 'secrets.yml'
+    class_option :secrets_path
 
     types = %w(
       vpc ec2 rds security_group elb network_acl route_table subnet nat_gateway network_interface alb

--- a/lib/awspec/generator.rb
+++ b/lib/awspec/generator.rb
@@ -26,6 +26,7 @@ require 'awspec/generator/spec/acm'
 require 'awspec/generator/spec/cloudwatch_logs'
 require 'awspec/generator/spec/alb'
 require 'awspec/generator/spec/internet_gateway'
+require 'awspec/generator/spec/elasticsearch'
 
 # Doc
 require 'awspec/generator/doc/type'

--- a/lib/awspec/generator/spec/elasticsearch.rb
+++ b/lib/awspec/generator/spec/elasticsearch.rb
@@ -1,35 +1,38 @@
 module Awspec::Generator
   module Spec
-    class ElasticSearch
+    class Elasticsearch
       include Awspec::Helper::Finder
       def generate_all
         domains = select_all_elasticsearch_domains
-        raise 'Not Found Domain' if events.empty?
-        ERB.new(domain_spec_template, nil, '-').result(binding).chomp
+        raise 'Not Found Domain' if domains.empty?
+        ERB.new(domain_spec_template, nil, '-').result(binding).gsub(/^\n/, '')
       end
 
       def domain_spec_template
         template = <<-'EOF'
-<% domain.each do |domain| %>
-describe elasticsearch('<%= domain.domain_name %>') do
+<% domains.each do |domain| %>
+describe elasticsearch('<%= domain.domain_status.domain_name %>') do
   it { should exist }
-  <% if domain.ebs_options.created %>
+<% if domain.domain_status.created %>
   it { should be_created }
-  <% end %>
-  <% if domain.ebs_options.deleted %>
+<% end %>
+<% if domain.domain_status.deleted %>
   it { should be_deleted }
-  <% end %>
-  its(:elasticsearch_version) { should eq <%= domain.elasticsearch_version %> }
-  its('elasticsearch_cluster_config.instance_type') { should eq <%= domain.elasticsearch_cluster_config.instance_type %> }
-  its('ebs_options.ebs_enabled') { should eq <%= domain.ebs_options.ebs_enabled %> }
-  <% if domain.ebs_options.ebs_enabled %>
-  its('ebs_options.volume_type') { should eq <%= domain.ebs_options.ebs_volume_type %> }
-  its('ebs_options.volume_size') { should eq <%= domain.ebs_options.ebs_volume_size %> }
-  <% end %>
+<% end %>
+  its(:elasticsearch_version) { should eq '<%= domain.domain_status.elasticsearch_version %>' }
+  its('elasticsearch_cluster_config.instance_type') { should eq '<%= domain.domain_status.elasticsearch_cluster_config.instance_type %>' }
+  its('ebs_options.ebs_enabled') { should eq <%= domain.domain_status.ebs_options.ebs_enabled %> }
+<% if domain.domain_status.ebs_options.ebs_enabled -%>
+  its('ebs_options.volume_type') { should eq '<%= domain.domain_status.ebs_options.volume_type %>' }
+  its('ebs_options.volume_size') { should eq <%= domain.domain_status.ebs_options.volume_size %> }
+<% end %>
   it do
     should have_access_policies <<-policy
-<%= JSON.pretty_generate(JSON.load(domain.access_policies)) %>
+<%= JSON.pretty_generate(JSON.load(domain.domain_status.access_policies)) %>
   policy
+  end
+end
+<% end %>
 EOF
         template
       end

--- a/lib/awspec/helper/finder/elasticsearch.rb
+++ b/lib/awspec/helper/finder/elasticsearch.rb
@@ -9,9 +9,9 @@ module Awspec::Helper
       end
 
       def select_all_elasticsearch_domains
-        domain_names = elastisearch_client.list_domain_names
-        domain_names.map do |domain_name|
-          elasticsearch_client.describe_elasticsearch_domain(domain_name)
+        domain_names = elasticsearch_client.list_domain_names.domain_names
+        domain_names.map do |domain|
+          elasticsearch_client.describe_elasticsearch_domain(domain_name: domain.domain_name)
         end
       end
     end

--- a/lib/awspec/type/route_table.rb
+++ b/lib/awspec/type/route_table.rb
@@ -42,13 +42,13 @@ module Awspec::Type
       return true if route.gateway_id == gateway_id
       # internet gateway
       igw = find_internet_gateway(gateway_id)
-      return true if igw && igw.tag_name == gateway_id
+      return true if igw && igw.internet_gateway_id == route.gateway_id
       # vpn gateway
       vgw = find_vpn_gateway(gateway_id)
-      return true if vgw && vgw.tag_name == gateway_id
+      return true if vgw && vgw.vpn_gateway_id == route.gateway_id
       # customer gateway
       cgw = find_customer_gateway(gateway_id)
-      return true if cgw && cgw.tag_name == gateway_id
+      return true if cgw && cgw.customer_gateway_id == route.gateway_id
       # nat gateway
       return true if route.nat_gateway_id == gateway_id
       false
@@ -58,7 +58,7 @@ module Awspec::Type
       # instance
       return true if route.instance_id == instance_id
       instance = find_ec2(instance_id)
-      return true if instance && instance.tag_name == instance_id
+      return true if instance && instance.instance_id == route.instance_id
       false
     end
 
@@ -71,7 +71,7 @@ module Awspec::Type
       # vpc_peering_connection_id
       return true if route.vpc_peering_connection_id == vpc_peering_connection_id
       connection = find_vpc_peering_connection(vpc_peering_connection_id)
-      return true if connection && connection.tag_name == vpc_peering_connection_id
+      return true if connection && connection.vpc_peering_connection_id == route.vpc_peering_connection_id
       false
     end
   end

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -12,7 +12,22 @@ module Awspec::Type
     end
 
     def associated_to? route_table_id
-      !find_route_table(route_table_id).nil?
+      res = ec2_client.describe_route_tables({
+        filters:
+        [
+          {
+            name:'association.subnet-id',
+            values: [id]
+          }
+        ]
+      })
+      return false unless res[:route_tables].length == 1
+      route_table = res[:route_tables][0]
+
+      name_tag = route_table.tags.select{|tag| tag.key == 'Name'}
+      name = name_tag.nil? ? nil : name_tag[0].value
+
+      route_table.route_table_id == route_table_id || name == route_table_id
     end
 
     STATES = %w(

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -11,6 +11,10 @@ module Awspec::Type
       @id ||= resource_via_client.subnet_id if resource_via_client
     end
 
+    def associated_to? route_table_id
+      !find_route_table(route_table_id).nil?
+    end
+
     STATES = %w(
       available pending
     )

--- a/lib/awspec/type/subnet.rb
+++ b/lib/awspec/type/subnet.rb
@@ -11,20 +11,20 @@ module Awspec::Type
       @id ||= resource_via_client.subnet_id if resource_via_client
     end
 
-    def associated_to? route_table_id
+    def associated_to?(route_table_id)
       res = ec2_client.describe_route_tables({
-        filters:
-        [
-          {
-            name:'association.subnet-id',
-            values: [id]
-          }
-        ]
-      })
+                                               filters:
+                                               [
+                                                 {
+                                                   name: 'association.subnet-id',
+                                                   values: [id]
+                                                 }
+                                               ]
+                                             })
       return false unless res[:route_tables].length == 1
       route_table = res[:route_tables][0]
 
-      name_tag = route_table.tags.select{|tag| tag.key == 'Name'}
+      name_tag = route_table.tags.select { |tag| tag.key == 'Name' }
       name = name_tag.nil? ? nil : name_tag[0].value
 
       route_table.route_table_id == route_table_id || name == route_table_id

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.75.2'
+  VERSION = '0.76.0'
 end

--- a/lib/awspec/version.rb
+++ b/lib/awspec/version.rb
@@ -1,3 +1,3 @@
 module Awspec
-  VERSION = '0.75.1'
+  VERSION = '0.75.2'
 end


### PR DESCRIPTION
Given a subnet you can assert that it is associated with a particular
route table:

```ruby
describe subnet('PublicSubnetAZ') do
  it { should be_associated_to('PublicRouteTable') }
end
```
https://github.com/aws/aws-sdk-ruby/issues/851